### PR TITLE
Added server_settings to call to mqtt.connect

### DIFF
--- a/mqtt.js
+++ b/mqtt.js
@@ -21,7 +21,7 @@ HermesMQTT.prototype.listen = function listen () {
 };
 
 HermesMQTT.prototype.connect = function connect () {
-  return mqtt.connect(this.server_settings.host_url || 'mqtt://localhost');
+  return mqtt.connect(this.server_settings.host_url || 'mqtt://localhost', this.server_settings);
 };
 
 HermesMQTT.prototype.setup = function setup () {


### PR DESCRIPTION
The mqtt.connect function can take an additional parameter containing username, password etc. This must be used to connect to any server that requires those parameters. This was discovered in trying to use a Solace router with the AsyncApi Streetlights tutorial.